### PR TITLE
 Added an empty region merge function for Phoenix's salting table.

### DIFF
--- a/hbase0.98/hbase-common-0.98/src/main/java/com/kakao/hbase/common/Args.java
+++ b/hbase0.98/hbase-common-0.98/src/main/java/com/kakao/hbase/common/Args.java
@@ -64,6 +64,7 @@ public abstract class Args {
     public static final String OPTION_INTERACTIVE = "interactive";
     public static final String OPTION_CONF = "conf";
     public static final String OPTION_CONF_SHORT = "c";
+    public static final String OPTION_PHOENIX = "phoenix-salting-table";
 
     public static final String INVALID_ARGUMENTS = "Invalid arguments";
     public static final String ALL_TABLES = "";

--- a/hbase0.98/hbase-common-0.98/src/main/java/com/kakao/hbase/common/LoadEntry.java
+++ b/hbase0.98/hbase-common-0.98/src/main/java/com/kakao/hbase/common/LoadEntry.java
@@ -400,7 +400,7 @@ public enum LoadEntry {
         if (one == null) {
             if (two == null) return null;
             else {
-                if (two == 0) {
+                if (two.intValue() == 0) {
                     return RatioNumber.ZERO.doubleValue();
                 } else {
                     return -two.doubleValue();
@@ -409,7 +409,7 @@ public enum LoadEntry {
         } else {
             if (two == null) return one.doubleValue();
             else {
-                if (two == 0) {
+                if (two.intValue() == 0) {
                     return one.doubleValue();
                 } else {
                     return one.doubleValue() - two.doubleValue();
@@ -432,7 +432,7 @@ public enum LoadEntry {
         if (one == null) {
             if (two == null) return null;
             else {
-                if (two == 0) {
+                if (two.intValue() == 0) {
                     return RatioNumber.ZERO;
                 } else {
                     return two;
@@ -441,9 +441,9 @@ public enum LoadEntry {
         } else {
             if (two == null) return one;
             else {
-                if (one == 0) {
+                if (one.intValue() == 0) {
                     return two;
-                } else if (two == 0) {
+                } else if (two.intValue() == 0) {
                     return one;
                 } else {
                     return ((RatioNumber) one).add((RatioNumber) two);

--- a/hbase0.98/hbase-manager-0.98/src/main/java/com/kakao/hbase/ManagerArgs.java
+++ b/hbase0.98/hbase-manager-0.98/src/main/java/com/kakao/hbase/ManagerArgs.java
@@ -40,6 +40,7 @@ public class ManagerArgs extends Args {
         optionParser.accepts(OPTION_LOCALITY_THRESHOLD).withRequiredArg().ofType(Double.class);
         optionParser.accepts(OPTION_CF).withRequiredArg().ofType(String.class);
         optionParser.accepts(OPTION_INTERACTIVE);
+        optionParser.accepts(OPTION_PHOENIX);
         return optionParser;
     }
 }

--- a/hbase0.98/hbase-table-stat-0.98/src/main/java/com/kakao/hbase/stat/load/Load.java
+++ b/hbase0.98/hbase-table-stat-0.98/src/main/java/com/kakao/hbase/stat/load/Load.java
@@ -145,7 +145,7 @@ public class Load {
     }
 
     public boolean isSummaryChanged(LoadEntry loadEntry) {
-        return summaryChangeMap.get(loadEntry) == ChangeState.changed.ordinal();
+        return summaryChangeMap.get(loadEntry).intValue() == ChangeState.changed.ordinal();
     }
 
     public boolean isDiffFromStart() {


### PR DESCRIPTION
In phoenix salting tables, boundary regions should not be merged because region boundaries must be preserved.
Fixed the part that compares number type to integer.
